### PR TITLE
Fix unusable firmware update screen

### DIFF
--- a/app/src/main/java/com/revolution/robotics/features/mainmenu/settings/firmware/FirmwareFragment.kt
+++ b/app/src/main/java/com/revolution/robotics/features/mainmenu/settings/firmware/FirmwareFragment.kt
@@ -27,7 +27,7 @@ class FirmwareFragment :
     }
 
     override fun onDestroyView() {
-        presenter.unregister()
+        presenter.unregister(this)
         super.onDestroyView()
     }
 


### PR DESCRIPTION
If an incompatible robot is connected from the firmware update settings screen, on the resulting screen the robot is not clickable. This is caused by the navigation: clicking the update button leaves the update fragment and enters an other update fragment, and it results in the following presenter registration and unregistration:
register(fragment1)
register(fragment2)
unregister(fragment1)
[user interacts with this state]

Fix this issue by making sure the presenter checks if it is unregistered by its owner.